### PR TITLE
Fixed duplicate timeouts causing a stuck state

### DIFF
--- a/src/main/java/de/erdbeerbaerlp/dcintegration/forge/DiscordIntegration.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/forge/DiscordIntegration.java
@@ -322,7 +322,12 @@ public class DiscordIntegration {
             discord_instance.sendMessage(Configuration.instance().localization.playerLeave.replace("%player%", ForgeMessageUtils.formatPlayerName(ev.player)));
         else if (discord_instance != null && timeouts.contains(ev.player.getUniqueID())) {
             discord_instance.sendMessage(Configuration.instance().localization.playerTimeout.replace("%player%", ForgeMessageUtils.formatPlayerName(ev.player)));
-            timeouts.remove(ev.player.getUniqueID());
+            //Fix for buggy timeouts causing leftovers in the timeout list
+            timeouts.forEach(e -> {
+                if (e.equals(ev.player.getUniqueID())) {
+                    timeouts.remove(e);
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
Had an issue where after a buggy timeout happened it added duplicate entries to the timeouts list, causing the disconnection message in discord to always be "x player timed out" when they were disconnecting normally. Now instead we check for *all* matching user timeouts and remove them in case that happens. :) Merging this into the rest of the versions *should* be safe with changing that refactored command name as well, but that's up to you.