### PR TITLE
[1.16.5] Remove debugging lines

### DIFF
--- a/src/main/java/de/erdbeerbaerlp/dcintegration/forge/util/ForgeMessageUtils.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/forge/util/ForgeMessageUtils.java
@@ -50,8 +50,6 @@ public class ForgeMessageUtils extends MessageUtils {
     public static MessageEmbed genItemStackEmbedIfAvailable(final ITextComponent component) {
         if (!Configuration.instance().forgeSpecific.sendItemInfo) return null;
         final JsonObject json = p.parse(ITextComponent.Serializer.toJson(component)).getAsJsonObject();
-        System.out.println("Generating embed...");
-        System.out.println("JSON: " + json);
         if (json.has("with")) {
             final JsonArray args = json.getAsJsonArray("with");
             for (JsonElement el : args) {


### PR DESCRIPTION
Looks like these lines were left in from creating the embed feature as this ends up spamming the console on every message sent.

```
[13:15:12] [Server thread/INFO] [STDOUT/]: [de.erdbeerbaerlp.dcintegration.forge.util.ForgeMessageUtils:genItemStackEmbedIfAvailable:53]: Generating embed...
[13:15:12] [Server thread/INFO] [STDOUT/]: [de.erdbeerbaerlp.dcintegration.forge.util.ForgeMessageUtils:genItemStackEmbedIfAvailable:54]: JSON: {"extra":[{"extra":[{"text":"<"},{"color":"dark_green","extra":[{"insertion":"mja00","clickEvent":{"action":"suggest_command","value":"/tell mja00 "},"hoverEvent":{"action":"show_entity","contents":{"type":"minecraft:player","id":"1043a019-7075-4c06-b02f-fb1dbb3b94b3","name":{"text":"mja00"}}},"extra":[{"text":"mja00"}],"text":""}],"text":""},{"text":">"}],"text":""},{"text":" "},{"text":"test"}],"text":""}
[13:15:12] [Server thread/INFO] [CHAT/]: <mja00> test
``` 